### PR TITLE
feat: Add detailed structure for AI Art Style Transfer App

### DIFF
--- a/ai_art_style_transfer/README.md
+++ b/ai_art_style_transfer/README.md
@@ -1,30 +1,84 @@
-# Ai Art Style Transfer
+# AI Art Style Transfer App
 
-**Type:** DL (CV + GANs)
+**Type:** DL (CV + GANs) - More accurately, primarily Deep Learning with Convolutional Neural Networks (CNNs). GANs can be an extension but are not core to basic style transfer.
 
 **Value Summary:** Creative industry, AR filters, photo apps
 
 ## Description
 
-(A more detailed description of the project will go here.)
+This project aims to implement Neural Style Transfer (NST), a technique that takes two images—a **content image** and a **style image**—and blends them together so the output image retains the core content of the content image but is painted in the artistic style of the style image. This is typically achieved by using a pre-trained Convolutional Neural Network (CNN) to extract content and style representations from the images and then optimizing a new image to match these representations.
 
-## Technologies to be Used
+## Key Technologies
 
-- (List potential technologies, frameworks, and libraries, e.g., Python, TensorFlow/PyTorch, scikit-learn, etc.)
+- **Programming Language:** Python
+- **Core Libraries:**
+    - **TensorFlow/Keras** or **PyTorch:** For building and potentially training the neural network components.
+    - **NumPy:** For numerical operations, especially image manipulation.
+    - **OpenCV (cv2):** For image loading, preprocessing (resizing, color space conversion), and postprocessing.
+    - **Matplotlib/Pillow (PIL):** For image display and saving.
+- **Pre-trained Model:** VGG16, VGG19, or similar, for feature extraction.
 
 ## Project Outline
 
-1.  **Data Collection/Preparation:** (Steps for acquiring and preprocessing data)
-2.  **Model Development:** (Steps for designing and building the AI model)
-3.  **Training:** (Steps for training the model)
-4.  **Evaluation:** (Steps for evaluating model performance)
-5.  **Deployment/Application:** (Steps for creating a usable application or inference script)
+1.  **Setup & Configuration:**
+    - Install necessary libraries.
+    - Set up project structure (already done).
+
+2.  **Image Loading and Preprocessing (`src/utils.py`):**
+    - Function to load content and style images from specified paths.
+    - Resize images to a consistent dimension for processing.
+    - Normalize pixel values (e.g., to [0, 1] range or VGG-specific normalization).
+    - Convert images to the format expected by the chosen deep learning framework (e.g., TensorFlow tensor).
+
+3.  **Model Definition (`src/nst_model.py`):**
+    - Load a pre-trained CNN (e.g., VGG19) without its classification head.
+    - Define layers from which content features will be extracted (typically one or more deeper layers).
+    - Define layers from which style features will be extracted (typically a set of layers across different depths).
+    - Create a model that takes an input image and outputs the feature maps from these selected content and style layers.
+
+4.  **Loss Functions (`src/nst_model.py` or `src/transfer_style.py`):**
+    - **Content Loss:** Measures how different the content representation of the generated image is from the content representation of the content image. Usually L2 distance between feature maps.
+    - **Style Loss:** Measures how different the style representation of the generated image is from the style representation of the style image. This involves calculating Gram matrices of the feature maps and finding the L2 distance between them.
+    - **Total Variation Loss (Optional):** A regularization term to encourage spatial smoothness in the generated image.
+
+5.  **Optimization Loop (`src/transfer_style.py`):**
+    - Initialize the generated image (e.g., from the content image or random noise).
+    - Define an optimizer (e.g., Adam, L-BFGS).
+    - Iteratively:
+        - Pass the generated image through the model to get its content and style features.
+        - Calculate content loss, style loss, and total variation loss.
+        - Compute the total loss (weighted sum of individual losses).
+        - Calculate gradients of the loss with respect to the pixels of the generated image.
+        - Apply gradients to update the generated image.
+        - Periodically save or display the intermediate results.
+
+6.  **Postprocessing and Output (`src/utils.py`, `src/transfer_style.py`):**
+    - Denormalize the generated image.
+    - Convert back to a standard image format (e.g., uint8 NumPy array).
+    - Save the final stylized image.
+    - Display the content, style, and generated images.
+
+7.  **Main Script (`src/transfer_style.py`):**
+    - Argument parsing for content image path, style image path, output path, number of iterations, loss weights, etc.
+    - Orchestrate the entire process: load images, build model, run optimization, save output.
+
+## Potential Next Steps & Enhancements
+
+- **User Interface:** Develop a simple GUI (e.g., using Tkinter, PyQt, or a web framework like Flask/Streamlit) to allow users to easily select images and run the style transfer.
+- **Optimization:**
+    - Experiment with different optimizers and learning rates.
+    - Explore techniques like Fast Neural Style Transfer (feed-forward generative networks) for real-time performance after initial model training.
+- **Model Variations:**
+    - Try different pre-trained models (e.g., Inception, ResNet).
+    - Implement adaptive style transfer techniques that offer more control over style elements.
+- **Hyperparameter Tuning:** Systematically tune weights for content, style, and total variation losses.
+- **Video Style Transfer:** Extend the concept to stylize video frames.
 
 ## TODO
 
-- [ ] Elaborate on project description.
-- [ ] List specific technologies.
-- [ ] Detail each step in the project outline.
-- [ ] Add code to `src/`.
-- [ ] Add example notebooks to `notebooks/`.
-- [ ] Add utility scripts to `scripts/`.
+- [x] Elaborate on project description.
+- [x] List specific technologies.
+- [x] Detail each step in the project outline.
+- [ ] Add code to `src/` for `nst_model.py`, `utils.py`, and `transfer_style.py`.
+- [ ] Add example notebooks to `notebooks/` demonstrating usage.
+- [ ] Add utility scripts to `scripts/` if needed (e.g., for downloading pre-trained models).

--- a/ai_art_style_transfer/src/nst_model.py
+++ b/ai_art_style_transfer/src/nst_model.py
@@ -1,0 +1,6 @@
+# ai_art_style_transfer/src/nst_model.py
+# This file will contain the neural style transfer model definition,
+# including loading pre-trained networks and defining loss functions.
+
+if __name__ == '__main__':
+    print(f"Placeholder for {__file__}")

--- a/ai_art_style_transfer/src/transfer_style.py
+++ b/ai_art_style_transfer/src/transfer_style.py
@@ -1,0 +1,7 @@
+# ai_art_style_transfer/src/transfer_style.py
+# This is the main script to orchestrate the neural style transfer process.
+# It will handle argument parsing, loading images, building the model,
+# running the optimization loop, and saving the output.
+
+if __name__ == '__main__':
+    print(f"Placeholder for {__file__}")

--- a/ai_art_style_transfer/src/utils.py
+++ b/ai_art_style_transfer/src/utils.py
@@ -1,0 +1,150 @@
+# ai_art_style_transfer/src/utils.py
+# This file will contain utility functions for image loading,
+# preprocessing (resizing, normalization), and postprocessing (denormalization, saving).
+
+import numpy as np
+import cv2 # OpenCV for image manipulation
+
+def load_image(image_path: str, max_dim: int = 512) -> np.ndarray:
+    """
+    Loads an image from the given file path, resizes it so its largest dimension
+    is max_dim (maintaining aspect ratio), and adds a batch dimension.
+
+    Args:
+        image_path (str): Path to the image file.
+        max_dim (int): The maximum size of the image's longer dimension.
+
+    Returns:
+        np.ndarray: The loaded and processed image as a float32 NumPy array
+                    in RGB format, with shape (1, height, width, 3).
+                    Returns None if the image cannot be loaded.
+    """
+    try:
+        img = cv2.imread(image_path)
+        if img is None:
+            print(f"Error: Image not found or corrupted at {image_path}")
+            return None
+
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) # Convert from BGR (OpenCV default) to RGB
+        img = img.astype(np.float32)
+
+        # Resize while maintaining aspect ratio
+        shape = np.array(img.shape[:-1], dtype=np.float32) # height, width
+        long_dim = max(shape)
+        scale = max_dim / long_dim
+
+        new_shape = tuple((shape * scale).astype(int))
+
+        img = cv2.resize(img, (new_shape[1], new_shape[0])) # cv2.resize expects (width, height)
+
+        img = img / 255.0 # Normalize to [0, 1] range
+        img = np.expand_dims(img, axis=0) # Add batch dimension
+
+        return img
+    except Exception as e:
+        print(f"An error occurred while loading image {image_path}: {e}")
+        return None
+
+def preprocess_image_vgg(image_tensor: np.ndarray) -> np.ndarray:
+    """
+    Preprocesses an image tensor for VGG-like models.
+    This typically involves subtracting mean pixel values and converting RGB to BGR.
+
+    Args:
+        image_tensor (np.ndarray): An image tensor, typically the output of load_image
+                                   (shape: 1, height, width, 3), pixels in [0,1] range.
+
+    Returns:
+        np.ndarray: The preprocessed image tensor.
+    """
+    if image_tensor is None:
+        return None
+
+    # VGG networks expect BGR images and mean pixel subtraction
+    # Mean pixel values (RGB) for VGG19 trained on ImageNet
+    vgg_mean = np.array([123.68, 116.779, 103.939], dtype=np.float32) # RGB
+
+    processed_img = image_tensor * 255.0 # Scale back to [0, 255] if it was [0,1]
+
+    # Subtract VGG mean (RGB order)
+    processed_img_rgb = processed_img.copy()
+    processed_img_rgb[..., 0] -= vgg_mean[0]
+    processed_img_rgb[..., 1] -= vgg_mean[1]
+    processed_img_rgb[..., 2] -= vgg_mean[2]
+
+    # Convert RGB to BGR
+    processed_img_bgr = processed_img_rgb[..., ::-1]
+
+    return processed_img_bgr
+
+def deprocess_image_vgg(processed_tensor: np.ndarray) -> np.ndarray:
+    """
+    Deprocesses an image tensor that was preprocessed for VGG models.
+    Reverses mean subtraction, BGR to RGB conversion, and clips to [0, 255].
+
+    Args:
+        processed_tensor (np.ndarray): The processed image tensor from the model.
+                                       Shape (1, height, width, 3), BGR order.
+
+    Returns:
+        np.ndarray: The deprocessed image as a uint8 NumPy array,
+                    RGB format, values in [0, 255].
+    """
+    if processed_tensor is None:
+        return None
+
+    img = processed_tensor.copy()
+    img = np.squeeze(img, axis=0) # Remove batch dimension
+
+    # Add VGG mean (BGR order for the array, but mean values are for RGB)
+    # VGG mean pixel values (RGB)
+    vgg_mean_rgb = np.array([123.68, 116.779, 103.939], dtype=np.float32)
+
+    # The tensor is BGR, so add mean in BGR order
+    img[..., 0] += vgg_mean_rgb[2] # Blue
+    img[..., 1] += vgg_mean_rgb[1] # Green
+    img[..., 2] += vgg_mean_rgb[0] # Red
+
+    # Clip to [0, 255] and convert to uint8
+    img = np.clip(img, 0, 255).astype('uint8')
+
+    # Convert BGR to RGB
+    img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
+    return img_rgb
+
+
+if __name__ == '__main__':
+    print(f"Utilities for Neural Style Transfer in {__file__}")
+    # Example Usage (requires an image file named 'test_image.jpg' in the script's directory)
+    # Create a dummy image for testing if one doesn't exist
+    dummy_image_path = "dummy_test_image.jpg"
+    if not cv2.imread(dummy_image_path):
+        dummy_array = np.random.randint(0, 256, (400, 600, 3), dtype=np.uint8)
+        cv2.imwrite(dummy_image_path, dummy_array)
+        print(f"Created dummy image at {dummy_image_path} for testing.")
+
+    print(f"Attempting to load image: {dummy_image_path}")
+    loaded_img_tensor = load_image(dummy_image_path, max_dim=256)
+    if loaded_img_tensor is not None:
+        print(f"Loaded image shape: {loaded_img_tensor.shape}")
+
+        preprocessed_tensor = preprocess_image_vgg(loaded_img_tensor)
+        if preprocessed_tensor is not None:
+            print(f"Preprocessed image tensor shape: {preprocessed_tensor.shape}")
+            print(f"Preprocessed image min/max: {preprocessed_tensor.min()}, {preprocessed_tensor.max()}")
+
+            deprocessed_img = deprocess_image_vgg(preprocessed_tensor)
+            if deprocessed_img is not None:
+                print(f"Deprocessed image shape: {deprocessed_img.shape}")
+                print(f"Deprocessed image min/max/dtype: {deprocessed_img.min()}, {deprocessed_img.max()}, {deprocessed_img.dtype}")
+                # cv2.imwrite("deprocessed_test_output.jpg", cv2.cvtColor(deprocessed_img, cv2.COLOR_RGB2BGR))
+                # print("Saved deprocessed_test_output.jpg")
+    else:
+        print(f"Failed to load {dummy_image_path}")
+
+    # Clean up dummy image
+    # import os
+    # if os.path.exists(dummy_image_path):
+    #     os.remove(dummy_image_path)
+    #     print(f"Cleaned up {dummy_image_path}")


### PR DESCRIPTION
This commit significantly fleshes out the "AI Art Style Transfer App" project.

Key changes include:
- Updated `ai_art_style_transfer/README.md` with:
    - A detailed description of Neural Style Transfer.
    - A list of key technologies (Python, TensorFlow/PyTorch, OpenCV, NumPy).
    - A comprehensive step-by-step project outline.
    - Potential next steps and enhancements.
- Created placeholder Python scripts in `ai_art_style_transfer/src/`:
    - `nst_model.py`: For the style transfer model.
    - `utils.py`: For image utilities.
    - `transfer_style.py`: For the main style transfer script.
- Implemented initial image utility functions in `ai_art_style_transfer/src/utils.py`:
    - `load_image()`: Loads, resizes (maintaining aspect ratio), normalizes to [0,1], and adds a batch dimension to an image.
    - `preprocess_image_vgg()`: Prepares an image tensor for VGG-like models by applying VGG mean subtraction and RGB to BGR conversion.
    - `deprocess_image_vgg()`: Reverses VGG preprocessing to get a viewable image.
    - Includes basic test code within `if __name__ == '__main__':` in `utils.py`.